### PR TITLE
Redesign: Startseite als Sternsystem (Tailwind 4)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,13 @@
 
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
   site: "https://example.com",
   integrations: [mdx(), sitemap()],
+  vite: {
+    plugins: [tailwindcss()],
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
+        "@tailwindcss/vite": "^4.3.2",
         "astro": "^6.1.5",
         "sharp": "^0.34.3",
+        "tailwindcss": "^4.3.2",
         "typescript": "^5.9.3"
       },
       "devDependencies": {
@@ -1294,11 +1296,50 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
@@ -1842,6 +1883,263 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
+      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
+      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-x64": "4.3.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
+      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
+      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
+      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
+      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
+      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
+      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
+      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
+      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
+      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
+      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
+      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
+      "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.2",
+        "@tailwindcss/oxide": "4.3.2",
+        "tailwindcss": "4.3.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2854,6 +3152,19 @@
         "@emmetio/css-abbreviation": "^2.1.8"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3292,6 +3603,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -3749,6 +4066,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3772,6 +4098,255 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5978,6 +6553,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
+    "@tailwindcss/vite": "^4.3.2",
     "astro": "^6.1.5",
     "sharp": "^0.34.3",
+    "tailwindcss": "^4.3.2",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,7 +1,4 @@
 ---
-// Import the global.css file here so that it is included on
-// all pages through the use of the <BaseHead /> component.
-import "@styles/global.css";
 import type { ImageMetadata } from "astro";
 import { SITE_TITLE } from "@ptypes/consts.ts";
 

--- a/src/components/GalleryMarquee.astro
+++ b/src/components/GalleryMarquee.astro
@@ -1,0 +1,43 @@
+---
+interface Props {
+  images: string[];
+  reverse?: boolean;
+  speed?: string;
+}
+
+const { images, reverse = false, speed } = Astro.props;
+// Duplicate once so the -50% keyframe loops seamlessly
+const doubled = [...images, ...images];
+---
+
+<div
+  class="flex overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]"
+>
+  <div
+    class:list={[
+      "flex w-max gap-6 px-3 hover:[animation-play-state:paused]",
+      reverse ? "animate-marquee-reverse" : "animate-marquee",
+    ]}
+    style={speed ? `animation-duration: ${speed}` : undefined}
+  >
+    {
+      doubled.map((src, i) => (
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          tabindex="-1"
+          aria-hidden={i >= images.length ? "true" : undefined}
+          class="block h-56 w-44 shrink-0 rounded-xl border-[3px] border-ink bg-paper p-2 shadow-[6px_6px_0_0_rgba(23,16,43,0.35)] transition-transform duration-300 odd:rotate-2 even:-rotate-2 hover:z-10 hover:rotate-0 hover:scale-105 md:h-72 md:w-56"
+        >
+          <img
+            src={src}
+            alt=""
+            loading="lazy"
+            class="h-full w-full rounded-lg object-cover"
+          />
+        </a>
+      ))
+    }
+  </div>
+</div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,13 +12,7 @@ const uniPosts = (await getCollection("uni")).sort(
 );
 ---
 
-<!doctype html>
-<html>
-  <head>
-    <style></style>
-  </head>
-  <body>
-    <nav>
+<nav>
       <h2><a href="/">{SITE_TITLE}</a></h2>
       <ul>
         <h4>Personal</h4>
@@ -45,5 +39,3 @@ const uniPosts = (await getCollection("uni")).sort(
         }
       </ul>
     </nav>
-  </body>
-</html>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -9,12 +9,6 @@ const subpath = pathname.match(/[^\/]+/g);
 const isActive = href === pathname || href === "/" + (subpath?.[0] || "");
 ---
 
-<!doctype html>
-<html lang="en">
-  <head> </head>
-  <body>
-    <a href={href} class:list={[className, { active: isActive }]} {...props}>
-      <slot />
-    </a>
-  </body>
-</html>
+<a href={href} class:list={[className, { active: isActive }]} {...props}>
+  <slot />
+</a>

--- a/src/components/StarSystem.astro
+++ b/src/components/StarSystem.astro
@@ -1,0 +1,201 @@
+---
+import GithubIcon from "@assets/github.svg";
+import { GITHUB_URL, SITE_AUTHOR, SITE_TAGLINE } from "@ptypes/consts.ts";
+import { getCollection, type CollectionEntry } from "astro:content";
+
+type Post = CollectionEntry<"personal"> | CollectionEntry<"uni">;
+
+const personalPosts = (await getCollection("personal")).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
+const uniPosts = (await getCollection("uni")).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
+
+// Golden-angle spiral: spreads n stars evenly inside the galaxy container (in %)
+function spiral(n: number): { x: number; y: number }[] {
+  return Array.from({ length: n }, (_, i) => {
+    const angle = i * 2.399963;
+    const r = Math.sqrt((i + 0.6) / n) * 40;
+    return {
+      x: 50 + r * Math.cos(angle),
+      y: 50 + r * Math.sin(angle),
+    };
+  });
+}
+
+interface Galaxy {
+  label: string;
+  base: string;
+  posts: Post[];
+  positions: { x: number; y: number }[];
+  glow: string;
+  nebula: string;
+  planet: string;
+  // container placement: mobile-first, md overrides
+  place: string;
+}
+
+const galaxies: Galaxy[] = [
+  {
+    label: "Personal",
+    base: "/blog/personal",
+    posts: personalPosts,
+    positions: spiral(personalPosts.length),
+    glow: "0 0 12px 3px rgba(255, 77, 141, 0.8)",
+    nebula:
+      "radial-gradient(ellipse at center, rgba(255,77,141,0.5), rgba(139,92,246,0.25) 55%, transparent 75%)",
+    planet: "radial-gradient(circle at 35% 35%, #ffd6e5, #ff4d8d 60%, #8b2a53)",
+    place: "left-1/2 top-[24%] md:left-[26%] md:top-[36%]",
+  },
+  {
+    label: "University",
+    base: "/blog/university",
+    posts: uniPosts,
+    positions: spiral(uniPosts.length),
+    glow: "0 0 12px 3px rgba(200, 245, 66, 0.8)",
+    nebula:
+      "radial-gradient(ellipse at center, rgba(200,245,66,0.4), rgba(94,234,212,0.25) 55%, transparent 75%)",
+    planet: "radial-gradient(circle at 35% 35%, #f2ffc2, #c8f542 60%, #5d7a10)",
+    place: "left-1/2 top-[79%] md:left-[73%] md:top-[62%]",
+  },
+];
+
+// Deterministic star dust sprinkled across the whole sky
+let seed = 42;
+const rand = () => {
+  seed = (seed * 9301 + 49297) % 233280;
+  return seed / 233280;
+};
+const dust = Array.from({ length: 60 }, () => ({
+  x: rand() * 100,
+  y: rand() * 100,
+  size: 1 + rand() * 2.5,
+  delay: rand() * 2.8,
+}));
+---
+
+<div class="pointer-events-none absolute inset-0 z-10">
+  {/* star dust */}
+  <div aria-hidden="true" class="absolute inset-0">
+    {
+      dust.map((d) => (
+        <div
+          class="absolute animate-twinkle rounded-full bg-paper"
+          style={`left:${d.x}%;top:${d.y}%;width:${d.size}px;height:${d.size}px;animation-delay:-${d.delay}s`}
+        />
+      ))
+    }
+  </div>
+
+  {/* galaxies */}
+  {
+    galaxies.map((galaxy) => (
+      <nav
+        aria-label={`${galaxy.label} projects`}
+        class:list={[
+          "absolute h-64 w-64 -translate-x-1/2 -translate-y-1/2 sm:h-80 sm:w-80 md:h-[26rem] md:w-[26rem]",
+          galaxy.place,
+        ]}
+      >
+        <div
+          aria-hidden="true"
+          class="absolute inset-[-15%] -rotate-12 rounded-full blur-2xl"
+          style={`background:${galaxy.nebula}`}
+        />
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          class="absolute inset-0 h-full w-full overflow-visible"
+        >
+          <polyline
+            points={galaxy.positions.map((p) => `${p.x},${p.y}`).join(" ")}
+            fill="none"
+            stroke="rgba(253,246,236,0.25)"
+            stroke-width="0.4"
+            stroke-dasharray="1.5 2"
+          />
+        </svg>
+        <p class="absolute -top-2 left-1/2 -translate-x-1/2 text-xs font-bold uppercase tracking-[0.35em] text-paper/70 md:text-sm">
+          {galaxy.label}
+        </p>
+        <ul>
+          {galaxy.posts.map((post, i) => {
+            const pos = galaxy.positions[i];
+            const isPlanet = i === 0;
+            return (
+              <li>
+                <a
+                  href={`${galaxy.base}/${post.id}/`}
+                  class="group pointer-events-auto absolute grid -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full p-2 focus-visible:outline-none"
+                  style={`left:${pos.x}%;top:${pos.y}%`}
+                >
+                  {isPlanet ? (
+                    <span class="relative block h-6 w-6 rounded-full transition-transform duration-300 group-hover:scale-125 md:h-8 md:w-8">
+                      <span
+                        class="absolute inset-0 rounded-full"
+                        style={`background:${galaxy.planet}`}
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="absolute left-1/2 top-1/2 h-[45%] w-[170%] -translate-x-1/2 -translate-y-1/2 -rotate-[24deg] rounded-full border border-paper/60"
+                      />
+                    </span>
+                  ) : (
+                    <span
+                      class="block animate-twinkle rounded-full bg-paper transition-transform duration-300 group-hover:scale-150"
+                      style={`width:${8 + ((i * 3) % 6)}px;height:${8 + ((i * 3) % 6)}px;box-shadow:${galaxy.glow};animation-delay:-${(i * 0.7) % 2.8}s`}
+                    />
+                  )}
+                  <span class="absolute left-1/2 top-full max-w-36 -translate-x-1/2 rounded-full bg-ink/85 px-2.5 py-1 text-center text-[11px] leading-tight text-paper/80 transition duration-200 group-hover:bg-grape group-hover:text-paper group-focus-visible:bg-grape group-focus-visible:text-paper md:whitespace-nowrap md:text-xs">
+                    {post.data.title}
+                  </span>
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    ))
+  }
+
+  {/* the sun */}
+  <div
+    class="absolute left-1/2 top-[49%] -translate-x-1/2 -translate-y-1/2 md:top-1/2"
+  >
+    <div class="relative mx-auto grid h-32 w-32 place-items-center md:h-44 md:w-44">
+      <div
+        aria-hidden="true"
+        class="absolute inset-0 rounded-full"
+        style="background:radial-gradient(circle at 35% 35%, #ffe9a3, #ffb02e 55%, #ff4d8d 95%);box-shadow:0 0 70px 25px rgba(255,176,46,0.35)"
+      >
+      </div>
+      <p class="relative text-2xl font-bold text-ink md:text-4xl">
+        {SITE_AUTHOR}
+      </p>
+      {/* orbiting github moon */}
+      <div
+        aria-hidden="false"
+        class="absolute inset-[-1.75rem] animate-orbit md:inset-[-2.25rem]"
+      >
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Julian on GitHub"
+          class="pointer-events-auto absolute left-1/2 top-0 grid h-9 w-9 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full bg-paper text-ink shadow-[0_0_14px_4px_rgba(253,246,236,0.4)] transition-transform hover:scale-110 focus-visible:ring-4 focus-visible:ring-punch md:h-10 md:w-10"
+        >
+          <span class="block animate-orbit-reverse">
+            <GithubIcon width="22px" height="22px" fill="currentColor" />
+          </span>
+        </a>
+      </div>
+    </div>
+    <p
+      class="mx-auto mt-12 w-max max-w-[80vw] rounded-full bg-ink/70 px-4 py-1.5 text-center text-xs text-paper/90 md:mt-14 md:text-sm"
+    >
+      {SITE_TAGLINE}
+    </p>
+  </div>
+</div>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,4 +2,8 @@
 // You can import this data from anywhere in your site by using the `import` keyword.
 
 export const SITE_TITLE = "Projects";
-export const SITE_DESCRIPTION = "Homepage for Varius of Projects";
+export const SITE_DESCRIPTION = "Homepage for various projects";
+export const SITE_AUTHOR = "Julian";
+export const GITHUB_URL = "https://github.com/JuLi0n21";
+export const SITE_TAGLINE =
+  "I build games, tools and uni projects — and occasionally write about them.";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,21 @@
+---
+import BaseHead from "@components/BaseHead.astro";
+import "@styles/theme.css";
+
+interface Props {
+  title: string;
+  description: string;
+}
+
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={title} description={description} />
+  </head>
+  <body class="bg-ink text-paper font-body min-h-dvh antialiased">
+    <slot />
+  </body>
+</html>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -2,6 +2,7 @@
 import BaseHead from "@components/BaseHead.astro";
 import Header from "@components/Header.astro";
 import GithubIcon from "@assets/github.svg";
+import "@styles/global.css";
 
 const { title, description, gitLink } = Astro.props;
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,182 +1,59 @@
 ---
-import BaseHead from "@components/BaseHead.astro";
-import Header from "@components/Header.astro";
+import type { ImageMetadata } from "astro";
+import BaseLayout from "@layouts/BaseLayout.astro";
+import GalleryMarquee from "@components/GalleryMarquee.astro";
+import StarSystem from "@components/StarSystem.astro";
 import { SITE_DESCRIPTION, SITE_TITLE } from "@ptypes/consts.ts";
 
-let top: string[] = [];
-let bottom: string[] = [];
-const api: string =
+const API =
   "https://fshare.kami.boo/api/server/folder/cmm9jbqvt00025omwu5cnpw9i";
-const response = await fetch(api);
 
-if (response.ok) {
+// Local images as fallback so the build never fails when the API is down
+const fallbackModules = import.meta.glob<{ default: ImageMetadata }>(
+  "../assets/homepage/*.{jpg,jpeg,png}",
+  { eager: true },
+);
+
+let files: string[] = [];
+try {
+  const response = await fetch(API, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
   const data = await response.json();
-  const files = data.files.map(
-(f: Response) => `https://shit-cache.illegalesachen.download/${btoa('https://fshare.kami.boo/raw' + f.url.substring(2))}`,
-  ) as string[];
-
-  const middle = Math.round(files.length / 2);
-  top = files.slice(0, middle);
-  bottom = files.slice(middle);
-} else {
-  const errorBody = await response.text();
-  console.error(
-    "FAILED TO FETCH",
-    response.status,
-    response.statusText,
-    errorBody,
+  files = data.files.map(
+    (f: { url: string }) =>
+      `https://shit-cache.illegalesachen.download/${btoa("https://fshare.kami.boo/raw" + f.url.substring(2))}`,
   );
-  process.exit(1);
+} catch (err) {
+  console.warn("[index] gallery API unreachable, using local fallback:", err);
+  files = Object.values(fallbackModules).map((m) => m.default.src);
 }
+
+files.sort(() => Math.random() - 0.5);
+const middle = Math.ceil(files.length / 2);
+const top = files.slice(0, middle);
+const bottom = files.slice(middle);
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-    <style>
-      .layout {
-        display: flex;
-        height: 100%;
-        width: 100%;
-      }
-
-      .sidebar {
-        height: 100vh;
-        display: flex;
-        flex-direction: column;
-        padding: 0;
-        box-sizing: border-box;
-        z-index: 10;
-        background: rgba(0, 0, 0, 0.5);
-        color: white;
-      }
-
-      .scrolling-gallery {
-        flex: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        overflow: hidden;
-        position: relative;
-        margin: 1cm;
-      }
-
-      main {
-        background: white;
-        overflow: hidden;
-      }
-
-      .gallery-wrapper {
-        display: flex;
-        flex-direction: column;
-        gap: 4rem;
-        transform: rotate(-8deg) scale(1.3);
-      }
-
-      .scroll-track {
-        display: flex;
-        gap: 3rem;
-        width: max-content;
-        animation: infiniteScroll 500s linear infinite;
-        padding: 0 2rem;
-      }
-
-      .track-reverse {
-        animation: infiniteScrollReverse 600s linear infinite;
-      }
-
-      .tilted-container {
-        width: 220px;
-        height: 280px;
-        flex-shrink: 0;
-        border-radius: 12px;
-        overflow: hidden;
-        transition: transform 0.3s ease;
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
-      }
-
-      .tilted-container:hover {
-        transform: scale(1.1);
-        z-index: 1;
-      }
-
-      .tilted-container img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        display: block;
-      }
-
-      @keyframes infiniteScroll {
-        0% {
-          transform: translateX(0%);
-        }
-        100% {
-          transform: translateX(-50%);
-        }
-      }
-
-      @keyframes infiniteScrollReverse {
-        0% {
-          transform: translateX(0%);
-        }
-        100% {
-          transform: translateX(50%);
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <div class="layout">
-      <aside class="sidebar">
-        <Header />
-      </aside>
-
-      <main class="scrolling-gallery">
-        <div class="gallery-wrapper">
-          <div id="top-images" class="scroll-track">
-            {
-              [...top, ...top].map((src) => (
-                <a class="tilted-container" href={src} target="_blank">
-                  <img src={src} loading="lazy" />
-                </a>
-              ))
-            }
-          </div>
-          {}
-          <div id="bottom-images" class="scroll-track track-reverse">
-            {
-              [...bottom, ...bottom].map((src) => (
-                <a class="tilted-container" href={src} target="_blank">
-                  <img src={src} loading="lazy" />
-                </a>
-              ))
-            }
-          </div>
-        </div>
-      </main>
+<BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION}>
+  <div class="relative min-h-dvh overflow-hidden">
+    {/* Background layer: counter-scrolling polaroid marquees */}
+    <div
+      class="absolute inset-0 flex -rotate-3 scale-105 flex-col justify-center gap-8 opacity-90 md:-rotate-6 md:scale-110 md:gap-10"
+      aria-hidden="true"
+    >
+      <GalleryMarquee images={top} speed="60s" />
+      <GalleryMarquee images={bottom} reverse speed="75s" />
     </div>
-    <script>
-      function shuffleImages(selector: string) {
-        const track = document.querySelector(selector);
-        if (!track) return;
 
-        const items = Array.from(track.children);
-        const shuffled = items.sort(() => Math.random() - 0.5);
+    {/* Dim layer so stars and labels stay readable over the gallery */}
+    <div class="absolute inset-0 bg-ink/60" aria-hidden="true"></div>
 
-        track.innerHTML = "";
-
-        const fragment = document.createDocumentFragment();
-        [...shuffled, ...shuffled].forEach((item) => {
-          fragment.appendChild(item.cloneNode(true));
-        });
-
-        track.appendChild(fragment);
-      }
-
-      shuffleImages("#top-images");
-      shuffleImages("#bottom-images");
-    </script>
-  </body>
-</html>
+    {/* Foreground: star-system navigation */}
+    <main>
+      <h1 class="sr-only">Julian — Projects</h1>
+      <StarSystem />
+    </main>
+  </div>
+</BaseLayout>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,103 @@
+@import "tailwindcss";
+
+@theme {
+  /* Sticker-board arcade palette */
+  --color-ink: #17102b;
+  --color-paper: #fdf6ec;
+  --color-grape: #8b5cf6;
+  --color-punch: #ff4d8d;
+  --color-lime: #c8f542;
+  --color-sky: #5eead4;
+
+  --font-body: "Atkinson", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Atkinson", ui-sans-serif, system-ui, sans-serif;
+
+  --animate-marquee: marquee 60s linear infinite;
+  --animate-marquee-reverse: marquee-reverse 75s linear infinite;
+  --animate-float: float 6s ease-in-out infinite;
+  --animate-wiggle: wiggle 0.4s ease-in-out;
+  --animate-twinkle: twinkle 2.8s ease-in-out infinite alternate;
+  --animate-orbit: orbit 24s linear infinite;
+  --animate-orbit-reverse: orbit-reverse 24s linear infinite;
+
+  @keyframes marquee {
+    to {
+      transform: translateX(-50%);
+    }
+  }
+  @keyframes marquee-reverse {
+    from {
+      transform: translateX(-50%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0) rotate(-1deg);
+    }
+    50% {
+      transform: translateY(-10px) rotate(1deg);
+    }
+  }
+  @keyframes wiggle {
+    0%,
+    100% {
+      transform: rotate(-2deg);
+    }
+    50% {
+      transform: rotate(2deg);
+    }
+  }
+  @keyframes twinkle {
+    from {
+      opacity: 0.45;
+      transform: scale(0.85);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1.15);
+    }
+  }
+  @keyframes orbit {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  @keyframes orbit-reverse {
+    to {
+      transform: rotate(-360deg);
+    }
+  }
+}
+
+@layer base {
+  @font-face {
+    font-family: "Atkinson";
+    src: url("/fonts/atkinson-regular.woff") format("woff");
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: "Atkinson";
+    src: url("/fonts/atkinson-bold.woff") format("woff");
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-marquee,
+  .animate-marquee-reverse,
+  .animate-float,
+  .animate-wiggle,
+  .animate-twinkle,
+  .animate-orbit,
+  .animate-orbit-reverse {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Was ist neu

Die Startseite hat ein komplett neues, verspieltes Design bekommen — die Navigation ist jetzt ein **Sternsystem**:

- **Julian als Sonne** im Zentrum, der GitHub-Link kreist als Mond drumherum
- **Kategorien als Galaxien**: Personal (pinker Nebel) und University (grüner Nebel)
- **Jeder Blogpost ist ein funkelnder Stern** mit Namens-Tag, angeordnet in einer Goldener-Winkel-Spirale mit Konstellationslinien
- **Der neueste Post pro Kategorie ist ein Planet mit Ring**
- Die **Bildergalerie bleibt** als Hintergrund erhalten (leicht abgedunkelt); Marquee-Geschwindigkeit von 500s/600s auf sichtbare 60s/75s korrigiert

## Technische Änderungen

- **Tailwind CSS 4** via `@tailwindcss/vite` eingeführt; Design-Tokens (Farben, Fonts, Animationen) CSS-first in `src/styles/theme.css`
- Neues `BaseLayout.astro` als sauberes Dokument-Shell für künftige Seiten-Migrationen

## Bugfixes

- `Header.astro` und `HeaderLink.astro` rendern keine verschachtelten `<html>/<body>`-Tags mehr innerhalb der Seiten
- Der Build schlägt nicht mehr fehl, wenn die Galerie-API down ist: `try/catch` mit 10s-Timeout und Fallback auf die lokalen Bilder in `src/assets/homepage/` (vorher `process.exit(1)`)
- Das Inline-Script auf der Startseite hat die bereits duplizierten Marquee-Tracks nochmal dupliziert (4x Bilder) — entfernt, Shuffle passiert jetzt zur Build-Zeit
- Typo in `SITE_DESCRIPTION` („Varius" → „various")

## Blogseiten unverändert

`global.css` wird jetzt von `BlogPost.astro` statt `BaseHead.astro` importiert — Blogseiten rendern dadurch identisch wie vorher (inkl. der eingebetteten Post-Styles wie beim FileClap-Theme). Die Blog-Migration aufs neue Design kann als nächster Schritt folgen.

## Barrierefreiheit

- `prefers-reduced-motion` stoppt Marquee, Funkeln und Orbit
- Sterne sind fokussierbare Links mit sichtbaren Labels
- `rel="noopener noreferrer"` auf allen externen Links, dekorative Bilder mit leerem `alt`

## Getestet

- `npm run build` inkl. `astro check` (strict) grün
- Desktop-, Tablet- und Mobile-Ansicht im Browser geprüft (alle 14 Posts erreichbar, nichts außerhalb des Viewports)
- Fallback-Test: Build mit unerreichbarer API läuft mit lokalen Bildern durch
- Hinweis: `package-lock.json` enthält die neuen Dependencies (Docker-Build via `npm ci` funktioniert); `bun.lock` wurde nicht aktualisiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)
